### PR TITLE
Fix up RDP exception

### DIFF
--- a/Source/DXControl/D2Phap.DXControl.csproj
+++ b/Source/DXControl/D2Phap.DXControl.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net7.0-windows;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net9.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -77,12 +77,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DirectNStandard" Version="1.17.0" />
+    <PackageReference Include="DirectNStandard" Version="1.17.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WicNet" Version="1.8.3" />
+    <PackageReference Include="WicNet" Version="1.8.4.1" />
   </ItemGroup>
 
 </Project>

--- a/Source/DXControl/DXCanvas.cs
+++ b/Source/DXControl/DXCanvas.cs
@@ -518,7 +518,7 @@ public class DXCanvas : Control
 
             try
             {
-                _device.EndDraw();
+                _device?.Object?.EndDraw(IntPtr.Zero, IntPtr.Zero);
             }
             catch (Win32Exception ex)
             {

--- a/Source/Demo/Demo.csproj
+++ b/Source/Demo/Demo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net6.0-windows;net7.0-windows;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net9.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
This PR does the following:
- Updates to use non EoL targets
- Fixes up the call to `EndDraw` to not be caught by DirectN, so that DXControl can do it's own handling on it.

This seems to work fine and fixes the remote desktop exception upon disconnecting / reconnecting

Relevant issue (ImageGlass): https://github.com/d2phap/ImageGlass/issues/2171